### PR TITLE
rename hash -> HASHING_ALGORITHM to be more descriptive and use keccac to make it verfiable

### DIFF
--- a/src/signing/adapters/base.ts
+++ b/src/signing/adapters/base.ts
@@ -59,4 +59,4 @@ export async function preSign(
 
 export const type = 'noop'
 // THIS IS THE RETURNED SIG HASH -- PLS look into ED25519 ASK JESSE IF SUPPORTED
-export const hash = 'sha3'
+export const HASHING_ALGORITHM = 'sha3'

--- a/src/signing/adapters/device-key-proxy.ts
+++ b/src/signing/adapters/device-key-proxy.ts
@@ -80,4 +80,4 @@ export async function preSign (
 
 export const type = 'deviceKeyProxy'
 // THIS IS THE RETURNED SIG HASH -- PLS look into ED25519 ASK JESSE IF SUPPORTED
-export const hash = 'sha3'
+export const HASHING_ALGORITHM = 'keccak'

--- a/src/signing/adapters/noop.ts
+++ b/src/signing/adapters/noop.ts
@@ -1,9 +1,7 @@
 import { HexString } from '../../keys/types/json'
 import { Signer } from '../../keys/types/internal'
-import { AUX_DATA, PRESIGN_RESULT } from './types'
+import { PRESIGN_RESULT } from './types'
 import { toHex } from '../../utils'
-
-
 
 /**
  *
@@ -13,18 +11,16 @@ import { toHex } from '../../utils'
 
 export type NoopAuxData = null
 
-
 /**
  * convenience object
  * */
 
 export const PROGRAM_INTERFACE = {
   // change this in file. this is peg's noop program. wasam path: @entropyxyz/sdk/tests/testing-utils/program_noop.wasm
-  program_pointer: '0x6c8228950ca8dfb557d42ce11643c67ba5a3e5cee3ce7232808ea7477b846bcb',
+  program_pointer:
+    '0x6c8228950ca8dfb557d42ce11643c67ba5a3e5cee3ce7232808ea7477b846bcb',
   program_config: null,
-  auxilary_data: [
-    null
-  ],
+  auxilary_data: [null],
 }
 
 export const ADAPTER_PROGRAMS = [PROGRAM_INTERFACE]
@@ -43,10 +39,9 @@ export async function preSign (
   // const signedMessage = deviceKey.pair.sign(stringMessage)
   const sigRequestHash = toHex(stringMessage)
 
-
   return { sigRequestHash, auxilary_data: PROGRAM_INTERFACE.auxilary_data }
 }
 
 export const type = 'noop'
 // THIS IS THE RETURNED SIG HASH
-export const hash = 'sha3'
+export const HASHING_ALGORITHM = 'keccak'

--- a/src/signing/adapters/types.ts
+++ b/src/signing/adapters/types.ts
@@ -25,7 +25,7 @@ export interface PRESIGN_RESULT {
  */
 export interface Adapter {
   type: string
-  hash: string
+  HASHING_ALGORITHM: string
   preSign?: (deviceKey: Signer, sigReq: MsgParams) => Promise<PRESIGN_RESULT>
   postSign?: (sig: Uint8Array, msgParams: MsgParams) => Promise<unknown>
   [key: string]: unknown

--- a/src/signing/index.ts
+++ b/src/signing/index.ts
@@ -147,7 +147,7 @@ export default class SignatureRequestManager {
     const { sigRequestHash } = results[0]
     const signature = await this.sign({
       sigRequestHash,
-      hash: adaptersToRun[0].hash,
+      hash: adaptersToRun[0].HASHING_ALGORITHM,
       auxiliaryData,
     })
     return signature


### PR DESCRIPTION
This pr is so that the cli can verify the signature against the verifying key using keccac.
This is also renames hash to be more understandable `HASHING_ALGORITHM` 