### PR TITLE
Frankie/i#291 opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Version header format: `[version] Name - year-month-day (entropy-core compatibil
 ### Fixed
 
 ### Changed
+- constructor now throws if you pass no object
 
 ### Broke
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,10 @@ export default class Entropy {
    * Initializes an instance of the Entropy class.
    *
    * @param {EntropyOpts} opts - The configuration options for the Entropy instance.
-   * @param {string} [opts.endpoint] - The endpoint for connecting to validators, either local or devnet.
-   * @param {Adapter[]} [opts.adapters] - A collection of signing adapters for handling various transaction types.
    */
 
   constructor (opts: EntropyOpts) {
+    if (!opts) throw new Error('missing opts object')
     this.ready = new Promise((resolve, reject) => {
       this.#ready = resolve
       this.#fail = reject

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -1,0 +1,21 @@
+import test from 'tape'
+
+import Entropy, { wasmGlobalsReady } from '../src'
+
+async function testSetup() {
+  await wasmGlobalsReady()
+}
+
+
+
+
+test('UNIT: constructor', async (t) => {
+  await testSetup()
+  try {
+    // @ts-ignore: next line (i need you to not do your job here)
+    new Entropy()
+  } catch (e) {
+    t.equal(e.message, 'missing opts object', 'should fail if no opts is passed')
+  }
+  t.end()
+})


### PR DESCRIPTION
closes #291 

`new Entropy()` now throws an error if missing opts object

- [x] has test
- [x] has CHANGELOG.md or dev/README.md entry/change 
- [ ] has docs change if needed
