### PR TITLE
simplify exports

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./dist/index.js')

--- a/index.cjs
+++ b/index.cjs
@@ -1,1 +1,1 @@
-module.exports = require('./dist/index.js')
+module.exports = require('./dist/index.cjs')

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,5 @@
+import { Entropy } from './dist/index.mjs'
+
+export default Entropy
+export * from './dist/index.mjs'
+

--- a/index.mjs
+++ b/index.mjs
@@ -1,5 +1,4 @@
-import { Entropy } from './dist/index.mjs'
+import { Entropy } from './dist/index.js'
 
 export default Entropy
-export * from './dist/index.mjs'
-
+export * from './dist/index.js'

--- a/keys.cjs
+++ b/keys.cjs
@@ -1,1 +1,1 @@
-module.exports = require('./dist/keys/index.js')
+module.exports = require('./dist/keys/index.cjs')

--- a/keys.cjs
+++ b/keys.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./dist/keys/index.js')

--- a/keys.mjs
+++ b/keys.mjs
@@ -1,5 +1,5 @@
-import { Keyring } from './dist/keys/index.mjs'
+import { Keyring } from './dist/keys/index.js'
 
 export default Keyring
-export * from './dist/keys/index.mjs'
+export * from './dist/keys/index.js'
 

--- a/keys.mjs
+++ b/keys.mjs
@@ -1,0 +1,5 @@
+import { Keyring } from './dist/keys/index.mjs'
+
+export default Keyring
+export * from './dist/keys/index.mjs'
+

--- a/package.json
+++ b/package.json
@@ -11,20 +11,19 @@
     "dist/**/*",
     "README.md"
   ],
-  "main": "./index.cjs",
-  "module": "./index.mjs",
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./index.cjs",
       "import": "./index.mjs",
       "require": "./index.cjs"
     },
     "./keys": {
-      "default": "./keys.cjs",
       "import": "./keys.mjs",
       "require": "./keys.cjs"
     }
   },
+  "module": "./index.mjs",
+  "main": "./index.cjs",
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "yarn test:setup && yarn test:types && yarn test:ts && yarn test:only && yarn test:require && yarn test:import",

--- a/package.json
+++ b/package.json
@@ -4,37 +4,25 @@
   "license": "AGPL-3.0-only",
   "description": "JS SDK for entropy blockchain ",
   "files": [
-    "dist",
-    "dist/keys",
-    "dist/keys/utils.ts",
-    "dist/utils"
+    "index.cjs",
+    "index.mjs",
+    "keys.cjs",
+    "keys.mjs",
+    "dist/**/*",
+    "README.md"
   ],
-  "type": "module",
+  "main": "./index.cjs",
+  "module": "./index.mjs",
   "exports": {
     ".": {
-      "module": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.js"
+      "default": "./index.cjs",
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./keys": {
-      "module": "./dist/keys/index.js",
-      "require": "./dist/keys/index.cjs",
-      "default": "./dist/keys/index.js"
-    },
-    "./keys/utils": {
-      "module": "./dist/keys/utils.js",
-      "require": "./dist/keys/utils.cjs",
-      "default": "./dist/keys/index.js"
-    },
-    "./crypto-utils": {
-      "module": "./dist/utils/crypto.js",
-      "require": "./dist/utils/crypto.cjs",
-      "default": "./dist/utils/crypto.js"
-    },
-    "./gen-utils": {
-      "module": "./dist/utils/index.js",
-      "require": "./dist/utils/index.cjs",
-      "default": "./dist/utils/index.js"
+      "default": "./keys.cjs",
+      "import": "./keys.mjs",
+      "require": "./keys.cjs"
     }
   },
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,3 +189,7 @@ export default class Entropy {
     }
   }
 }
+
+export {
+  Entropy
+}

--- a/src/keys/index.ts
+++ b/src/keys/index.ts
@@ -205,3 +205,7 @@ export default class Keyring {
     })
   }
 }
+
+export {
+  Keyring
+}

--- a/tests/import.test.mjs
+++ b/tests/import.test.mjs
@@ -1,20 +1,23 @@
 import test from 'tape'
-import Entropy, { wasmGlobalsReady } from '@entropyxyz/sdk'
-import Keyring from '@entropyxyz/sdk/keys'
+import DefaultEntropy, { Entropy, wasmGlobalsReady } from '../index.mjs'
+import DefaultKeyring, { Keyring } from '../keys.mjs'
 
 const charlieSeed = '0xbc1ede780f784bb6991a585e4f6e61522c14e1cae6ad0895fb57b9a205a8f938'
 
 test('ESM import', async t => {
   try {
+    t.deepEqual(DefaultEntropy, Entropy, 'Entropy exported as default + named')
     await wasmGlobalsReady()
-    const keyring = new Keyring({ seed: charlieSeed })
-    t.deepEqual(typeof keyring, 'object', 'keyring')
-
     t.true(
       typeof Entropy === 'function'
       && Entropy.name === 'Entropy',
-      'Entropy class'
+      'Entropy is a class'
     )
+
+    t.deepEqual(DefaultKeyring, Keyring, 'Keyring exported as default + named')
+    const keyring = new Keyring({ seed: charlieSeed })
+    t.deepEqual(typeof keyring, 'object', 'Keyring works')
+
   } catch (err) {
     t.error(err, 'no errors')
   }

--- a/tests/import.test.mjs
+++ b/tests/import.test.mjs
@@ -1,6 +1,6 @@
 import test from 'tape'
-import DefaultEntropy, { Entropy, wasmGlobalsReady } from '../index.mjs'
-import DefaultKeyring, { Keyring } from '../keys.mjs'
+import DefaultEntropy, { Entropy, wasmGlobalsReady } from '@entropyxyz/sdk'
+import DefaultKeyring, { Keyring } from '@entropyxyz/sdk/keys'
 
 const charlieSeed = '0xbc1ede780f784bb6991a585e4f6e61522c14e1cae6ad0895fb57b9a205a8f938'
 

--- a/tests/require.test.cjs
+++ b/tests/require.test.cjs
@@ -1,20 +1,23 @@
 const test = require('tape')
-const { default: Entropy, wasmGlobalsReady } = require('@entropyxyz/sdk')
-const { default: Keyring } = require('@entropyxyz/sdk/keys')
+const { default: DefaultEntropy, Entropy, wasmGlobalsReady } = require('@entropyxyz/sdk')
+const { default: DefaultKeyring, Keyring } = require('@entropyxyz/sdk/keys')
 
 const charlieSeed = '0xbc1ede780f784bb6991a585e4f6e61522c14e1cae6ad0895fb57b9a205a8f938'
 
 test('CJS require', async t => {
-
   try {
+    t.deepEqual(DefaultEntropy, Entropy, 'Entropy exported as default + named')
     await wasmGlobalsReady()
-    const keyring = new Keyring({ seed: charlieSeed })
-    t.deepEqual(typeof keyring, 'object', 'keyring')
-
     t.true(
-      typeof Entropy === 'function' && Entropy.name === 'Entropy',
-      'Entropy class'
+      typeof Entropy === 'function'
+      && Entropy.name === 'Entropy',
+      'Entropy is a class'
     )
+
+    t.deepEqual(DefaultKeyring, Keyring, 'Keyring exported as default + named')
+    const keyring = new Keyring({ seed: charlieSeed })
+    t.deepEqual(typeof keyring, 'object', 'Keyring works')
+
   } catch (err) {
     t.error(err, 'no errors')
   }


### PR DESCRIPTION
This PR:
- :fire: cuts off some exports that weren't used
- introduces simple files in root of project which handle routing to correct files
