### PR TITLE
Add `entropyxyz` organization username to allowlist.

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -46,6 +46,6 @@ jobs:
           path-to-signatures: 'legal/cla/v1/signatures.json'
           path-to-document: 'https://github.com/entropyxyz/.github/blob/main/legal/cla/v1/cla.md'
           branch: 'main'
-          allowlist: dependabot[bot]
+          allowlist: dependabot[bot],entropyxyz
           remote-organization-name: entropyxyz
           remote-repository-name: .github


### PR DESCRIPTION
It is unlikely that users belonging to the `entropyxyz` GitHub Organization are required to sign the CLA. To automatically allow any Organization member to bypass the requirements to sign the CLA, merge this PR.