### PR TITLE
add api option on polkadot to shush its warning logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export default class Entropy {
   async #init (opts: EntropyOpts) {
     this.keyring = opts.keyring
     const wsProvider = new WsProvider(opts.endpoint)
-    this.substrate = new ApiPromise({ provider: wsProvider })
+    this.substrate = new ApiPromise({ provider: wsProvider, noInitWarn: true })
     await this.substrate.isReadyOrError // throws an error if fails
 
     this.registrationManager = new RegistrationManager({


### PR DESCRIPTION
related https://github.com/entropyxyz/cli/issues/48
closes #303 

I tested this manually had to temporarily disable `patch-package`  i think because the cli is also has a polkadot dependency or my misunderstanding of are tooling we still get the warning logs from the api on creation in the cli. this should quiet those.