### PR TITLE
add more docker spin-up time for mix's laptop

### DIFF
--- a/dev/testing-utils.mjs
+++ b/dev/testing-utils.mjs
@@ -31,7 +31,7 @@ export async function spinNetworkUp (networkType = 'four-nodes') {
 
 async function retryUntil (fn, isSuccess = Boolean, opts = {}) {
   const {
-    triesRemaining = process.env.GITHUB_WORKSPACE ? 60 : 10,
+    triesRemaining = process.env.GITHUB_WORKSPACE ? 60 : 20,
     timeout = 1 * SECONDS
   } = opts
   return fn()


### PR DESCRIPTION
my little laptop needs 11s to spin up the docker containers :cry: 

I've been hacking the `node_modules` but it's annoying, so here we go!